### PR TITLE
Edit formatting and remove unused steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,27 @@
-TXT Adder -  PowerShell script for Dynu DNS
-Description
+# TXT Adder -  PowerShell script for Dynu DNS
 	
-Prerequisites
-?	Certify The Web 4.1.6.0 or Higher
-?	PowerShell 3.0 or Higher
+## Prerequisites
+* Certify The Web 4.1.6.0 or Higher
+* PowerShell 3.0 or Higher
 
-Installation
-?	Open PowerShellAPIDynu Folder 
-?	Right click on "Setup.ps1"
-?	Click on "Run with PowerShell"
-?	Enter the Dynu API Key when prompted
-?	Open "Certify the Web"
-?	Click on "New Certificate"
-?	Delete "New managed Certificate" and enter your domain i.e. "test.dynu.net"
-?	In Certificate Domains
-?	Click on "Select Website (optional):" Default Web Site or the correct IIS Server
-?	Below is "Add domains to certificate:" enter your domain i.e. "test.dynu.net"
-?	Go to "Authorization"
-?	In "Domain Match" enter your domain i.e. "test.dynu.net"
-?	On "Challenge Type:" change to "dns-01"
-?	On "DNS Update Method:" change to "(Use Custom Script)"
-?	Create Script Path: "C:\TXTAdder\CTW_TXT_Add.bat"
-?	Delete Script Path: "C:\TXTAdder\CTW_TXT_Delete.bat"
-?	Click "Save"
-?	Click "Request Certificate"
+## Installation
+* Open PowerShellAPIDynu Folder 
+* Right click on "Setup.ps1"
+* Click on "Run with PowerShell"
+* Enter the Dynu API Key when prompted
+* Open "Certify the Web"
+* Click on "New Certificate"
+* Delete "New managed Certificate" and enter a name for this managed certificate i.e. "test.dynu.net" or other name
+* In Certificate Domains
+	* Click on "Select Website (optional):" Default Web Site or the correct IIS Server
+	* Below "Add domains to certificate:" enter your domain i.e. "test.dynu.net"
+* Go to "Authorization"
+	* On "Challenge Type:" change to "dns-01"
+	* On "DNS Update Method:" change to "(Use Custom Script)"
+* Create Script Path: "C:\TXTAdder\CTW_TXT_Add.bat"
+* Delete Script Path: "C:\TXTAdder\CTW_TXT_Delete.bat"
+* Click "Save"
+* Click "Request Certificate"
 
 License - MIT License
 


### PR DESCRIPTION
- Add formatting
- Clarify that managed certificate name is just an identifier and not necessarily the domain (usually this is the IIS site name)
- Removed Authorizations steps to match domain, that's only used if you have multiple authorization types in one certificate.